### PR TITLE
Fix city name reference

### DIFF
--- a/br_populate.rb
+++ b/br_populate.rb
@@ -20,7 +20,7 @@ module BRPopulate
 
       state["cities"].each do |city|
         c = City.new
-        c.name = city
+        c.name = city["name"]
         c.state = state_obj
         c.capital = capital?(city, state)
         c.save


### PR DESCRIPTION
Fix city normalisation from JSON to ruby object. 

It was setting the full object `{ "name": "Acrelândia", "code": "1200013" }`. Change to set only the name.